### PR TITLE
fix attachment of two commas

### DIFF
--- a/gl_treegal-ud-train.conllu
+++ b/gl_treegal-ud-train.conllu
@@ -47,7 +47,7 @@
 21	nosa	noso	DET	Md1pfs	Gender=Fem|Number=Sing|Number[psor]=Plur|Person=1|Poss=Yes|PronType=Prs	22	det	_	_
 22	identidade	identidade	NOUN	Scfs	Gender=Fem|Number=Sing	18	obj	_	_
 23	política	político	ADJ	A0fs	Gender=Fem|Number=Sing	22	amod	_	SpaceAfter=No
-24	,	,	PUNCT	Q,	_	22	punct	_	_
+24	,	,	PUNCT	Q,	_	25	punct	_	_
 25	cultural	cultural	ADJ	A0fs	Gender=Fem|Number=Sing	23	conj	_	_
 26	e	e	CCONJ	Cc	_	27	cc	_	_
 27	lingüística	lingüístico	ADJ	A0fs	Gender=Fem|Number=Sing	23	conj	_	SpaceAfter=No
@@ -802,7 +802,7 @@
 42	as	o	DET	Ddfp	Definite=Def|Gender=Fem|Number=Plur|PronType=Art	43	det	_	_
 43	eleccións	elección	NOUN	Scfp	Gender=Fem|Number=Plur	39	nmod	_	_
 44	autonómicas	autonómico	ADJ	A0fp	Gender=Fem|Number=Plur	43	amod	_	SpaceAfter=No
-45	,	,	PUNCT	Q,	_	33	punct	_	_
+45	,	,	PUNCT	Q,	_	48	punct	_	_
 46	senón	senón	SCONJ	Cs	_	48	cc	_	_
 47	que	que	SCONJ	Cs	_	48	mark	_	_
 48	suxería	suxerir	VERB	Vii30s	Mood=Ind|Number=Sing|Person=3|Tense=Imp|VerbForm=Fin	33	conj	_	_


### PR DESCRIPTION
[sent_id=8](https://github.com/UniversalDependencies/UD_Galician-TreeGal/blob/65ff198a6df69a6391ed6113665c5abee6796391/gl_treegal-ud-train.conllu#L46-L53)
contained a comma which should be attached to the following conjunct
``` 
 ╭─╼ a DET det
 ├─╼ nosa DET det
─┾ identidade NOUN obj
 ├─────────────────┮ política ADJ amod
 ├─╼ , PUNCT punct │
 │                 ├─╼ cultural ADJ conj
 │                 │ ╭─╼ e CCONJ cc
 │                 ╰─┶ lingüística ADJ conj
```

Similarly in [sent_id=118](https://github.com/UniversalDependencies/UD_Galician-TreeGal/blob/65ff198a6df69a6391ed6113665c5abee6796391/gl_treegal-ud-train.conllu#L805)
```
   ╰─┾ demandaba VERB advcl
     │ ╭─╼ o DET det
     │ ├─╼ primeiro NUM nummod
     ├─┾ posto NOUN obj
     │ │ ╭─╼ de ADP case
     │ │ ├─╼ a DET det
     │ ╰─┾ candidatura NOUN nmod
     │   ├─╼ coruñesa ADJ amod
     │   │ ╭─╼ a ADP case
     │   │ ├─╼ as DET det
     │   ╰─┾ eleccións NOUN nmod
     │     ╰─╼ autonómicas ADJ amod
     ├─╼ , PUNCT punct
     │ ╭─╼ senón SCONJ cc
     │ ├─╼ que SCONJ mark
     ╰─┾ suxería VERB conj
```
